### PR TITLE
chwVertexBind: Updated deformer name in makePaintable mel command.

### DIFF
--- a/src/chwVertexBind.cpp
+++ b/src/chwVertexBind.cpp
@@ -95,7 +95,7 @@ MStatus chwVertexBind::initialize()
 	attributeAffects(chwVertexBind::aInitialize, 	chwVertexBind::outputGeom);
 	attributeAffects(chwVertexBind::aVertexMap,		chwVertexBind::outputGeom);
 
-	MGlobal::executeCommand( "makePaintable -attrType \"multiFloat\" -sm \"deformer\" \"vertSnap\" \"weights\";" );
+	MGlobal::executeCommand( "makePaintable -attrType \"multiFloat\" -sm \"deformer\" \"chwVertexBind\" \"weights\";" );
 
 	return MStatus::kSuccess;
 }


### PR DESCRIPTION
Looks like this node was previously named `vertSnap`. This updates the mel command with the current name of the node.